### PR TITLE
🔒 Fix path traversal vulnerability in SaveVisualizationAsFile

### DIFF
--- a/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
+++ b/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
@@ -21,7 +21,30 @@ namespace OpenQA.Selenium.Appium.ImageComparison
 
         public void SaveVisualizationAsFile(string fileName)
         {
-            File.WriteAllBytes(fileName, Convert.FromBase64String(Visualization));
+            if (string.IsNullOrEmpty(fileName))
+            {
+                throw new ArgumentNullException(nameof(fileName));
+            }
+
+            if (fileName.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+            {
+                throw new ArgumentException("The file name contains invalid characters.", nameof(fileName));
+            }
+
+            string allowedDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
+            if (!allowedDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                allowedDirectory += Path.DirectorySeparatorChar;
+            }
+
+            string fullPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), fileName));
+
+            if (!fullPath.StartsWith(allowedDirectory, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new IOException("Path traversal or absolute path overwrite is not allowed. The file must be saved within the allowed directory.");
+            }
+
+            File.WriteAllBytes(fullPath, Convert.FromBase64String(Visualization));
         }
 
         protected Rectangle ConvertToRect(object value)

--- a/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
+++ b/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
@@ -8,6 +8,9 @@ namespace OpenQA.Selenium.Appium.ImageComparison
 {
     public abstract class ComparisonResult
     {
+        private static readonly System.Reflection.PropertyInfo LinkTargetProperty = 
+            typeof(FileSystemInfo).GetProperty("LinkTarget");
+
         /// <summary>
         /// The visualization of the matching result represented as base64-encoded PNG image.
         /// </summary>
@@ -47,7 +50,7 @@ namespace OpenQA.Selenium.Appium.ImageComparison
 
             string fullPath = Path.GetFullPath(Path.Combine(currentDirectory, fileName));
 
-            var comparison = (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? StringComparison.OrdinalIgnoreCase
                 : StringComparison.Ordinal;
 
@@ -81,33 +84,81 @@ namespace OpenQA.Selenium.Appium.ImageComparison
             {
                 currentPath = Path.Combine(currentPath, part);
 
-                if (Directory.Exists(currentPath) || File.Exists(currentPath))
+                if (IsSymbolicLink(currentPath))
                 {
-                    FileAttributes attributes;
-                    try
-                    {
-                        attributes = File.GetAttributes(currentPath);
-                    }
-                    catch (IOException)
-                    {
-                        // If attributes cannot be read, treat the path as unsafe.
-                        return true;
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        // If attributes cannot be read due to permissions, treat the path as unsafe.
-                        return true;
-                    }
-
-                    if ((attributes & FileAttributes.ReparsePoint) != 0)
-                    {
-                        // A reparse point (including symlinks/junctions) is present along the path.
-                        return true;
-                    }
+                    return true;
                 }
             }
 
             return false;
+        }
+
+        private static bool IsSymbolicLink(string path)
+        {
+            if (LinkTargetProperty != null)
+            {
+                try
+                {
+                    FileSystemInfo info = Directory.Exists(path) 
+                        ? (FileSystemInfo)new DirectoryInfo(path) 
+                        : new FileInfo(path);
+                    var target = LinkTargetProperty.GetValue(info) as string;
+                    if (target != null)
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // Fall through
+                }
+            }
+
+            try
+            {
+                if (FileSystemEntryExists(path))
+                {
+                    var attributes = File.GetAttributes(path);
+                    if ((attributes & FileAttributes.ReparsePoint) != 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                if (FileSystemEntryExists(path))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool FileSystemEntryExists(string path)
+        {
+            try
+            {
+                string parent = Path.GetDirectoryName(path);
+                if (string.IsNullOrEmpty(parent))
+                {
+                    return false;
+                }
+
+                if (!Directory.Exists(parent))
+                {
+                    return false;
+                }
+
+                string name = Path.GetFileName(path);
+                string[] entries = Directory.GetFileSystemEntries(parent, name);
+                return entries != null && entries.Length > 0;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         protected Rectangle ConvertToRect(object value)

--- a/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
+++ b/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace OpenQA.Selenium.Appium.ImageComparison
 {
@@ -21,9 +22,14 @@ namespace OpenQA.Selenium.Appium.ImageComparison
 
         public void SaveVisualizationAsFile(string fileName)
         {
-            if (string.IsNullOrEmpty(fileName))
+            if (fileName is null)
             {
                 throw new ArgumentNullException(nameof(fileName));
+            }
+
+            if (fileName.Length == 0)
+            {
+                throw new ArgumentException("The file name must not be an empty string.", nameof(fileName));
             }
 
             if (fileName.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
@@ -31,20 +37,77 @@ namespace OpenQA.Selenium.Appium.ImageComparison
                 throw new ArgumentException("The file name contains invalid characters.", nameof(fileName));
             }
 
-            string allowedDirectory = Path.GetFullPath(Directory.GetCurrentDirectory());
-            if (!allowedDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()))
+            string currentDirectory = Directory.GetCurrentDirectory();
+            string allowedDirectory = Path.GetFullPath(currentDirectory);
+            if (!allowedDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()) &&
+                !allowedDirectory.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
             {
                 allowedDirectory += Path.DirectorySeparatorChar;
             }
 
-            string fullPath = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), fileName));
+            string fullPath = Path.GetFullPath(Path.Combine(currentDirectory, fileName));
 
-            if (!fullPath.StartsWith(allowedDirectory, StringComparison.OrdinalIgnoreCase))
+            var comparison = (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
+            if (!fullPath.StartsWith(allowedDirectory, comparison))
             {
                 throw new IOException("Path traversal or absolute path overwrite is not allowed. The file must be saved within the allowed directory.");
             }
 
+            string relativePath = fullPath.Substring(allowedDirectory.Length);
+
+            if (ContainsSymlinkWithinBaseDirectory(allowedDirectory, relativePath))
+            {
+                throw new IOException("The path to the output file traverses a symbolic link or reparse point, which is not allowed.");
+            }
+
             File.WriteAllBytes(fullPath, Convert.FromBase64String(Visualization));
+        }
+
+        private static bool ContainsSymlinkWithinBaseDirectory(string allowedDirectory, string relativePath)
+        {
+            if (string.IsNullOrEmpty(relativePath) || relativePath.Equals(".", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+            string[] parts = relativePath.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+
+            string currentPath = allowedDirectory;
+            foreach (string part in parts)
+            {
+                currentPath = Path.Combine(currentPath, part);
+
+                if (Directory.Exists(currentPath) || File.Exists(currentPath))
+                {
+                    FileAttributes attributes;
+                    try
+                    {
+                        attributes = File.GetAttributes(currentPath);
+                    }
+                    catch (IOException)
+                    {
+                        // If attributes cannot be read, treat the path as unsafe.
+                        return true;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        // If attributes cannot be read due to permissions, treat the path as unsafe.
+                        return true;
+                    }
+
+                    if ((attributes & FileAttributes.ReparsePoint) != 0)
+                    {
+                        // A reparse point (including symlinks/junctions) is present along the path.
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         protected Rectangle ConvertToRect(object value)

--- a/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
+++ b/src/Appium.Net/Appium/ImageComparison/ComparisonResult.cs
@@ -40,6 +40,23 @@ namespace OpenQA.Selenium.Appium.ImageComparison
                 throw new ArgumentException("The file name contains invalid characters.", nameof(fileName));
             }
 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                int colonIndex = fileName.IndexOf(':');
+                if (colonIndex >= 0)
+                {
+                    bool isValidDriveSpecifier = fileName.Length >= 2 && 
+                                                 char.IsLetter(fileName[0]) && 
+                                                 colonIndex == 1 && 
+                                                 fileName.IndexOf(':', 2) == -1;
+
+                    if (!isValidDriveSpecifier)
+                    {
+                        throw new ArgumentException("The file name contains invalid characters or alternate data streams.", nameof(fileName));
+                    }
+                }
+            }
+
             string currentDirectory = Directory.GetCurrentDirectory();
             string allowedDirectory = Path.GetFullPath(currentDirectory);
             if (!allowedDirectory.EndsWith(Path.DirectorySeparatorChar.ToString()) &&

--- a/test/integration/ImageComparison/ComparisonResultTests.cs
+++ b/test/integration/ImageComparison/ComparisonResultTests.cs
@@ -152,16 +152,15 @@ namespace Appium.Net.Integration.Tests.ImageComparison
                     Assert.Ignore("Skipping symlink test: Failed to create symbolic link (not supported or permissions issue).");
                     return;
                 }
-#else
-                Assert.Ignore("Skipping symlink test: Symbolic links are not supported on this target framework.");
-                return;
-#endif
 
                 // Attempt to write a file via the symlink
                 string fileName = Path.Combine("local_sub", "symlink_dir", "image.png");
 
                 var ex = Assert.Throws<IOException>(() => _comparisonResult.SaveVisualizationAsFile(fileName));
                 Assert.That(ex.Message, Does.Contain("symbolic link or reparse point"));
+#else
+                Assert.Ignore("Skipping symlink test: Symbolic links are not supported on this target framework.");
+#endif
             }
             finally
             {

--- a/test/integration/ImageComparison/ComparisonResultTests.cs
+++ b/test/integration/ImageComparison/ComparisonResultTests.cs
@@ -178,5 +178,37 @@ namespace Appium.Net.Integration.Tests.ImageComparison
                 }
             }
         }
+
+        [Test]
+        public void SaveVisualizationAsFile_BrokenFileSymlinkTraversal_ThrowsIOException()
+        {
+#if NET6_0_OR_GREATER
+            // Create a target file path that does not exist
+            string externalFile = Path.Combine(Path.GetTempPath(), "nonexistent_external_target_" + Guid.NewGuid().ToString("N") + ".png");
+
+            // Create a file symlink pointing to the non-existent external file
+            string symlinkPath = Path.Combine(_testDir, "broken_file_link.png");
+
+            try
+            {
+                File.CreateSymbolicLink(symlinkPath, externalFile);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Assert.Ignore("Skipping symlink test: No permissions to create symbolic links on this OS/user.");
+                return;
+            }
+            catch (IOException)
+            {
+                Assert.Ignore("Skipping symlink test: Failed to create symbolic link (not supported or permissions issue).");
+                return;
+            }
+
+            var ex = Assert.Throws<IOException>(() => _comparisonResult.SaveVisualizationAsFile("broken_file_link.png"));
+            Assert.That(ex.Message, Does.Contain("symbolic link or reparse point"));
+#else
+            Assert.Ignore("Skipping symlink test: Symbolic links are not supported on this target framework.");
+#endif
+        }
     }
 }

--- a/test/integration/ImageComparison/ComparisonResultTests.cs
+++ b/test/integration/ImageComparison/ComparisonResultTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium.ImageComparison;
 
@@ -16,6 +17,7 @@ namespace Appium.Net.Integration.Tests.ImageComparison
     [TestFixture]
     public class ComparisonResultTests
     {
+        private string _originalCwd;
         private string _testDir;
         private TestComparisonResult _comparisonResult;
         private const string DummyBase64 = "c29tZSB2aXN1YWxpemF0aW9uIGRhdGE="; // "some visualization data"
@@ -24,7 +26,8 @@ namespace Appium.Net.Integration.Tests.ImageComparison
         [SetUp]
         public void SetUp()
         {
-            _testDir = Path.Combine(Directory.GetCurrentDirectory(), "test_output_" + Guid.NewGuid().ToString("N"));
+            _originalCwd = Directory.GetCurrentDirectory();
+            _testDir = Path.Combine(_originalCwd, "test_output_" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_testDir);
             Directory.SetCurrentDirectory(_testDir);
 
@@ -39,9 +42,10 @@ namespace Appium.Net.Integration.Tests.ImageComparison
         [TearDown]
         public void TearDown()
         {
-            // Restore current directory before deleting
-            string originalDir = Path.GetFullPath(Path.Combine(_testDir, ".."));
-            Directory.SetCurrentDirectory(originalDir);
+            if (!string.IsNullOrEmpty(_originalCwd))
+            {
+                Directory.SetCurrentDirectory(_originalCwd);
+            }
 
             try
             {
@@ -208,6 +212,21 @@ namespace Appium.Net.Integration.Tests.ImageComparison
 #else
             Assert.Ignore("Skipping symlink test: Symbolic links are not supported on this target framework.");
 #endif
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_AlternateDataStreamsOnWindows_ThrowsArgumentException()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                string invalidFileName = "file.png:stream";
+                var ex = Assert.Throws<ArgumentException>(() => _comparisonResult.SaveVisualizationAsFile(invalidFileName));
+                Assert.That(ex.Message, Does.Contain("alternate data streams"));
+            }
+            else
+            {
+                Assert.Pass("Skipping alternate data streams test: Only runs on Windows.");
+            }
         }
     }
 }

--- a/test/integration/ImageComparison/ComparisonResultTests.cs
+++ b/test/integration/ImageComparison/ComparisonResultTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium.ImageComparison;
+
+namespace Appium.Net.Integration.Tests.ImageComparison
+{
+    public class TestComparisonResult : ComparisonResult
+    {
+        public TestComparisonResult(Dictionary<string, object> result) : base(result)
+        {
+        }
+    }
+
+    [TestFixture]
+    public class ComparisonResultTests
+    {
+        private string _testDir;
+        private TestComparisonResult _comparisonResult;
+        private const string DummyBase64 = "c29tZSB2aXN1YWxpemF0aW9uIGRhdGE="; // "some visualization data"
+        private byte[] _expectedBytes;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _testDir = Path.Combine(Directory.GetCurrentDirectory(), "test_output_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_testDir);
+            Directory.SetCurrentDirectory(_testDir);
+
+            var dict = new Dictionary<string, object>
+            {
+                { "visualization", DummyBase64 }
+            };
+            _comparisonResult = new TestComparisonResult(dict);
+            _expectedBytes = Convert.FromBase64String(DummyBase64);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Restore current directory before deleting
+            string originalDir = Path.GetFullPath(Path.Combine(_testDir, ".."));
+            Directory.SetCurrentDirectory(originalDir);
+
+            try
+            {
+                if (Directory.Exists(_testDir))
+                {
+                    Directory.Delete(_testDir, true);
+                }
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_NullFileName_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _comparisonResult.SaveVisualizationAsFile(null));
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_EmptyFileName_ThrowsArgumentException()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => _comparisonResult.SaveVisualizationAsFile(""));
+            Assert.That(ex.Message, Does.Contain("The file name must not be an empty string."));
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_InvalidCharacters_ThrowsArgumentException()
+        {
+            char[] invalidChars = Path.GetInvalidPathChars();
+            if (invalidChars.Length > 0)
+            {
+                string invalidFileName = "test" + invalidChars[0] + ".png";
+                var ex = Assert.Throws<ArgumentException>(() => _comparisonResult.SaveVisualizationAsFile(invalidFileName));
+                Assert.That(ex.Message, Does.Contain("The file name contains invalid characters."));
+            }
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_ValidFileName_SavesFile()
+        {
+            string fileName = "valid_image.png";
+            _comparisonResult.SaveVisualizationAsFile(fileName);
+
+            string fullPath = Path.Combine(_testDir, fileName);
+            Assert.That(File.Exists(fullPath), Is.True);
+            Assert.That(File.ReadAllBytes(fullPath), Is.EqualTo(_expectedBytes));
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_ValidSubdirectoryFileName_SavesFile()
+        {
+            string subDir = "subdir";
+            Directory.CreateDirectory(Path.Combine(_testDir, subDir));
+            string fileName = Path.Combine(subDir, "valid_image.png");
+            
+            _comparisonResult.SaveVisualizationAsFile(fileName);
+
+            string fullPath = Path.Combine(_testDir, fileName);
+            Assert.That(File.Exists(fullPath), Is.True);
+            Assert.That(File.ReadAllBytes(fullPath), Is.EqualTo(_expectedBytes));
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_PathTraversalParentDirectory_ThrowsIOException()
+        {
+            string fileName = "../traversal_image.png";
+            Assert.Throws<IOException>(() => _comparisonResult.SaveVisualizationAsFile(fileName));
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_AbsolutePathOutsideAllowed_ThrowsIOException()
+        {
+            string absolutePath = Path.Combine(Path.GetTempPath(), "absolute_image.png");
+            Assert.Throws<IOException>(() => _comparisonResult.SaveVisualizationAsFile(absolutePath));
+        }
+
+        [Test]
+        public void SaveVisualizationAsFile_SymlinkTraversal_ThrowsIOException()
+        {
+            // Create a subfolder inside allowed directory
+            string localSubDir = Path.Combine(_testDir, "local_sub");
+            Directory.CreateDirectory(localSubDir);
+
+            // Create a target directory outside allowed directory (we'll simulate it by placing it next to _testDir)
+            string parentDir = Path.GetFullPath(Path.Combine(_testDir, ".."));
+            string externalDir = Path.Combine(parentDir, "external_target_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(externalDir);
+
+            try
+            {
+                // Create a directory symlink inside local_sub pointing to externalDir
+                string symlinkPath = Path.Combine(localSubDir, "symlink_dir");
+                
+#if NET6_0_OR_GREATER
+                try
+                {
+                    Directory.CreateSymbolicLink(symlinkPath, externalDir);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Assert.Ignore("Skipping symlink test: No permissions to create symbolic links on this OS/user.");
+                    return;
+                }
+                catch (IOException)
+                {
+                    Assert.Ignore("Skipping symlink test: Failed to create symbolic link (not supported or permissions issue).");
+                    return;
+                }
+#else
+                Assert.Ignore("Skipping symlink test: Symbolic links are not supported on this target framework.");
+                return;
+#endif
+
+                // Attempt to write a file via the symlink
+                string fileName = Path.Combine("local_sub", "symlink_dir", "image.png");
+
+                var ex = Assert.Throws<IOException>(() => _comparisonResult.SaveVisualizationAsFile(fileName));
+                Assert.That(ex.Message, Does.Contain("symbolic link or reparse point"));
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(externalDir))
+                    {
+                        Directory.Delete(externalDir, true);
+                    }
+                }
+                catch
+                {
+                    // Ignore cleanup errors for external directory
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** The `SaveVisualizationAsFile` method lacked validation on the user-supplied `fileName`, directly writing the Base64 visualization to the provided path.
⚠️ **Risk:** An attacker controlling the filename could provide an absolute path (`C:\Windows\System32\malicious.dll`) or use relative path traversal (`../../etc/passwd`) to overwrite arbitrary files on the local filesystem.
🛡️ **Solution:** The method now restricts the output file location to the application's current working directory. It uses `Path.GetFullPath` combined with `StartsWith` (aware of target operating system case sensitivity) to ensure that no directory traversal sequences or absolute paths escape the allowed base directory. Symbolic links/reparse points are also detected and blocked. Invalid path characters are rejected by throwing an exception.

---
*PR created automatically by Jules for task [2834004444876715981](https://jules.google.com/task/2834004444876715981) started by @Dor-bl*
