### PR TITLE
feat: add iOS launchAppWithArguments

### DIFF
--- a/src/Appium.Net/Appium/iOS/IOSCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/iOS/IOSCommandExecutionHelper.cs
@@ -142,7 +142,7 @@ namespace OpenQA.Selenium.Appium.iOS
 
             executeMethod.Execute(DriverCommand.ExecuteScript, new Dictionary<string, object>
             {
-                ["script"] = "mobile:launchApp",
+                ["script"] = "mobile: launchApp",
                 ["args"] = new object[] { args }
             });
         }

--- a/src/Appium.Net/Appium/iOS/IOSCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/iOS/IOSCommandExecutionHelper.cs
@@ -118,6 +118,35 @@ namespace OpenQA.Selenium.Appium.iOS
             });
         }
 
+        /// <summary>
+        /// Launch an app on the iOS device using mobile: launchApp script.
+        /// For documentation, see <see href="https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-launchapp">mobile: launchApp</see>.
+        /// </summary>
+        /// <param name="executeMethod">The execute method</param>
+        /// <param name="bundleId">The bundle identifier of the application.</param>
+        /// <param name="processArguments">Optional command line arguments for the app.</param>
+        /// <param name="environmentVariables">Optional environment variables for the app.</param>
+        public static void LaunchAppWithArguments(
+            IExecuteMethod executeMethod,
+            string bundleId,
+            IReadOnlyCollection<string> processArguments = null,
+            IDictionary<string, string> environmentVariables = null)
+        {
+            var args = new Dictionary<string, object> { { "bundleId", bundleId } };
+
+            if (processArguments != null && processArguments.Count > 0)
+                args["arguments"] = processArguments;
+
+            if (environmentVariables != null && environmentVariables.Count > 0)
+                args["environment"] = environmentVariables;
+
+            executeMethod.Execute(DriverCommand.ExecuteScript, new Dictionary<string, object>
+            {
+                ["script"] = "mobile:launchApp",
+                ["args"] = new object[] { args }
+            });
+        }
+
         public static Dictionary<string, object> GetSettings(IExecuteMethod executeMethod) =>
             (Dictionary<string, object>)executeMethod.Execute(AppiumDriverCommand.GetSettings).Value;
 

--- a/src/Appium.Net/Appium/iOS/IOSDriver.cs
+++ b/src/Appium.Net/Appium/iOS/IOSDriver.cs
@@ -211,6 +211,19 @@ namespace OpenQA.Selenium.Appium.iOS
         public void InstallApp(string appPath, int? timeoutMs = null) =>
             IOSCommandExecutionHelper.InstallApp(this, appPath, timeoutMs);
 
+        /// <summary>
+        /// Launch an app on the iOS device using mobile: launchApp script.
+        /// For documentation, see <see href="https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-launchapp">mobile: launchApp</see>.
+        /// </summary>
+        /// <param name="bundleId">The bundle identifier of the application.</param>
+        /// <param name="processArguments">Optional command line arguments for the app.</param>
+        /// <param name="environmentVariables">Optional environment variables for the app.</param>
+        public void LaunchAppWithArguments(
+            string bundleId,
+            IReadOnlyCollection<string> processArguments = null,
+            IDictionary<string, string> environmentVariables = null) =>
+            IOSCommandExecutionHelper.LaunchAppWithArguments(this, bundleId, processArguments, environmentVariables);
+
         #endregion
 
         /// <summary>

--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -87,6 +87,34 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
 
         #endregion
 
+        #region Launch App With Arguments
+
+        [Test]
+        public void CanLaunchAppWithArguments()
+        {
+            _driver.TerminateApp(UiCatalogAppTestAppBundleId);
+
+            var processArguments = new List<string>
+            {
+                "-AppleLanguages",
+                "(en)",
+                "-AppleLocale",
+                "en_US"
+            };
+            var environmentVariables = new Dictionary<string, string>
+            {
+                ["UITEST_LAUNCH"] = "1"
+            };
+
+            Assert.DoesNotThrow(() =>
+                _driver.LaunchAppWithArguments(UiCatalogAppTestAppBundleId, processArguments, environmentVariables));
+
+            Assert.That(() => _driver.GetAppState(UiCatalogAppTestAppBundleId), Is.EqualTo(AppState.RunningInForeground));
+            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(UiCatalogTestAppElement)));
+        }
+
+        #endregion
+
         #region Background App
 
         [Test]


### PR DESCRIPTION
## Summary
- add iOS helper and driver method for mobile:launchApp with arguments/env
- add integration test covering LaunchAppWithArguments
- adjust test to use installed UICatalog bundle id

## Testing
- dotnet test test/integration/Appium.Net.Integration.Tests.csproj -f net8.0 --nologo --filter FullyQualifiedName~CanLaunchAppWithArguments