### PR TITLE
docs: remove obsolete CI badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 ----
 
 [![Functional Tests](https://github.com/appium/dotnet-client/actions/workflows/functional-test.yml/badge.svg)](https://github.com/appium/dotnet-client/actions/workflows/functional-test.yml)
-[![Functional Tests (Android)](https://github.com/appium/dotnet-client/actions/workflows/functional-android-test.yml/badge.svg)](https://github.com/appium/dotnet-client/actions/workflows/functional-android-test.yml)
-[![Functional Tests (iOS)](https://github.com/appium/dotnet-client/actions/workflows/functional-ios-test.yml/badge.svg)](https://github.com/appium/dotnet-client/actions/workflows/functional-ios-test.yml)
 [![Unit Tests](https://github.com/appium/dotnet-client/actions/workflows/unit-test.yml/badge.svg)](https://github.com/appium/dotnet-client/actions/workflows/unit-test.yml)
 
 ----


### PR DESCRIPTION
Removes the `functional-android-test` and `functional-ios-test` badges from the README, as these workflows were consolidated into `functional-test.yml`.