### PR TITLE
chore: remove prerelease identifier from release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,5 +48,4 @@ version-resolver:
   default: patch
   
 prerelease: false
-prerelease-identifier: 'rc'
 contribution-template: '- $NAME contributed via $PULL_REQUEST'


### PR DESCRIPTION
This PR removes the `-rc` suffix from release drafts since we are no longer generating prereleases.