### PR TITLE
feat(ios): implement syslog broadcast support in IOSDriver

### DIFF
--- a/src/Appium.Net/Appium/WebSocket/StringWebSocketClient.cs
+++ b/src/Appium.Net/Appium/WebSocket/StringWebSocketClient.cs
@@ -272,7 +272,7 @@ namespace OpenQA.Selenium.Appium.WebSocket
         /// </summary>
         private async Task DisconnectInternalAsync()
         {
-            if (_clientWebSocket.State == WebSocketState.Open)
+            if (_clientWebSocket?.State == WebSocketState.Open)
             {
                 try
                 {

--- a/src/Appium.Net/Appium/iOS/IOSDriver.cs
+++ b/src/Appium.Net/Appium/iOS/IOSDriver.cs
@@ -18,14 +18,18 @@ using OpenQA.Selenium.Appium.Service;
 using System;
 using System.Drawing;
 using OpenQA.Selenium.Appium.iOS.Interfaces;
+using OpenQA.Selenium.Appium.WebSocket;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Appium.iOS
 {
     public class IOSDriver : AppiumDriver, IHidesKeyboardWithKeyName, IHasClipboard,
-        IShakesDevice, IPerformsTouchID, IHasSettings
+        IShakesDevice, IPerformsTouchID, IHasSettings, IListensToSyslogMessages
     {
         private static readonly string Platform = MobilePlatform.IOS;
+        private readonly StringWebSocketClient _syslogClient = new();
+        private const int DefaultAppiumPort = 4723;
 
         /// <summary>
         /// Initializes a new instance of the IOSDriver class
@@ -328,5 +332,104 @@ namespace OpenQA.Selenium.Appium.iOS
                     ]
                 ).ToString()
             );
+
+        #region Syslog Broadcast
+
+        /// <summary>
+        /// Start syslog messages broadcast via web socket.
+        /// This method assumes that Appium server is running on localhost and
+        /// is assigned to the default port (4723).
+        /// </summary>
+        /// <remarks>
+        /// This implementation uses a custom WebSocket endpoint and is temporary.
+        /// In the future, this functionality will be replaced with WebDriver BiDi log events
+        /// when BiDi support for iOS device logs becomes available.
+        /// </remarks>
+        public async Task StartSyslogBroadcast() => await StartSyslogBroadcast("127.0.0.1", DefaultAppiumPort);
+
+        /// <summary>
+        /// Start syslog messages broadcast via web socket.
+        /// This method assumes that Appium server is assigned to the default port (4723).
+        /// </summary>
+        /// <param name="host">The name of the host where Appium server is running.</param>
+        /// <remarks>
+        /// This implementation uses a custom WebSocket endpoint and is temporary.
+        /// In the future, this functionality will be replaced with WebDriver BiDi log events
+        /// when BiDi support for iOS device logs becomes available.
+        /// </remarks>
+        public async Task StartSyslogBroadcast(string host) => await StartSyslogBroadcast(host, DefaultAppiumPort);
+
+        /// <summary>
+        /// Start syslog messages broadcast via web socket.
+        /// </summary>
+        /// <param name="host">The name of the host where Appium server is running.</param>
+        /// <param name="port">The port of the host where Appium server is running.</param>
+        /// <remarks>
+        /// This implementation uses a custom WebSocket endpoint and is temporary.
+        /// In the future, this functionality will be replaced with WebDriver BiDi log events
+        /// when BiDi support for iOS device logs becomes available.
+        /// </remarks>
+        public async Task StartSyslogBroadcast(string host, int port)
+        {
+            ExecuteScript("mobile: startLogsBroadcast", new Dictionary<string, object>());
+            var endpointUri = new Uri($"ws://{host}:{port}/ws/session/{SessionId}/appium/device/syslog");
+            await _syslogClient.ConnectAsync(endpointUri);
+        }
+
+        /// <summary>
+        /// Adds a new log messages broadcasting handler.
+        /// Several handlers might be assigned to a single server.
+        /// Multiple calls to this method will cause such handler
+        /// to be called multiple times.
+        /// </summary>
+        /// <param name="handler">A function, which accepts a single argument, which is the actual log message.</param>
+        public void AddSyslogMessagesListener(Action<string> handler) =>
+            _syslogClient.AddMessageHandler(handler);
+
+        /// <summary>
+        /// Adds a new log broadcasting errors handler.
+        /// Several handlers might be assigned to a single server.
+        /// Multiple calls to this method will cause such handler
+        /// to be called multiple times.
+        /// </summary>
+        /// <param name="handler">A function, which accepts a single argument, which is the actual exception instance.</param>
+        public void AddSyslogErrorsListener(Action<Exception> handler) =>
+            _syslogClient.AddErrorHandler(handler);
+
+        /// <summary>
+        /// Adds a new log broadcasting connection handler.
+        /// Several handlers might be assigned to a single server.
+        /// Multiple calls to this method will cause such handler
+        /// to be called multiple times.
+        /// </summary>
+        /// <param name="handler">A function, which is executed as soon as the client is successfully connected to the web socket.</param>
+        public void AddSyslogConnectionListener(Action handler) =>
+            _syslogClient.AddConnectionHandler(handler);
+
+        /// <summary>
+        /// Adds a new log broadcasting disconnection handler.
+        /// Several handlers might be assigned to a single server.
+        /// Multiple calls to this method will cause such handler
+        /// to be called multiple times.
+        /// </summary>
+        /// <param name="handler">A function, which is executed as soon as the client is successfully disconnected from the web socket.</param>
+        public void AddSyslogDisconnectionListener(Action handler) =>
+            _syslogClient.AddDisconnectionHandler(handler);
+
+        /// <summary>
+        /// Removes all existing syslog handlers.
+        /// </summary>
+        public void RemoveAllSyslogListeners() => _syslogClient.RemoveAllHandlers();
+
+        /// <summary>
+        /// Stops syslog messages broadcast via web socket.
+        /// </summary>
+        public async Task StopSyslogBroadcast()
+        {
+            ExecuteScript("mobile: stopLogsBroadcast", new Dictionary<string, object>());
+            await _syslogClient.DisconnectAsync();
+        }
+
+        #endregion
     }
 }

--- a/src/Appium.Net/Appium/iOS/IOSDriver.cs
+++ b/src/Appium.Net/Appium/iOS/IOSDriver.cs
@@ -372,7 +372,15 @@ namespace OpenQA.Selenium.Appium.iOS
         public async Task StartSyslogBroadcast(string host, int port)
         {
             ExecuteScript("mobile: startLogsBroadcast", new Dictionary<string, object>());
-            var endpointUri = new Uri($"ws://{host}:{port}/ws/session/{SessionId}/appium/device/syslog");
+            // Use UriBuilder so IPv6 literal hosts (e.g. "::1") are bracketed correctly;
+            // string interpolation would produce an invalid authority and throw UriFormatException.
+            var endpointUri = new UriBuilder
+            {
+                Scheme = "ws",
+                Host = host,
+                Port = port,
+                Path = $"/ws/session/{SessionId}/appium/device/syslog"
+            }.Uri;
             try
             {
                 await _syslogClient.ConnectAsync(endpointUri);

--- a/src/Appium.Net/Appium/iOS/IOSDriver.cs
+++ b/src/Appium.Net/Appium/iOS/IOSDriver.cs
@@ -373,7 +373,24 @@ namespace OpenQA.Selenium.Appium.iOS
         {
             ExecuteScript("mobile: startLogsBroadcast", new Dictionary<string, object>());
             var endpointUri = new Uri($"ws://{host}:{port}/ws/session/{SessionId}/appium/device/syslog");
-            await _syslogClient.ConnectAsync(endpointUri);
+            try
+            {
+                await _syslogClient.ConnectAsync(endpointUri);
+            }
+            catch
+            {
+                // The server-side broadcast was already started above; stop it so a failed
+                // WebSocket connection does not leave an orphaned broadcast on the Appium server.
+                try
+                {
+                    ExecuteScript("mobile: stopLogsBroadcast", new Dictionary<string, object>());
+                }
+                catch
+                {
+                    // Best-effort cleanup; surface the original connection failure below.
+                }
+                throw;
+            }
         }
 
         /// <summary>
@@ -426,8 +443,16 @@ namespace OpenQA.Selenium.Appium.iOS
         /// </summary>
         public async Task StopSyslogBroadcast()
         {
-            ExecuteScript("mobile: stopLogsBroadcast", new Dictionary<string, object>());
-            await _syslogClient.DisconnectAsync();
+            try
+            {
+                ExecuteScript("mobile: stopLogsBroadcast", new Dictionary<string, object>());
+            }
+            finally
+            {
+                // Always disconnect the client so a failure stopping the server-side
+                // broadcast does not leave the WebSocket receive loop running.
+                await _syslogClient.DisconnectAsync();
+            }
         }
 
         #endregion

--- a/src/Appium.Net/Appium/iOS/Interfaces/IListensToSyslogMessages.cs
+++ b/src/Appium.Net/Appium/iOS/Interfaces/IListensToSyslogMessages.cs
@@ -13,6 +13,7 @@
 //limitations under the License.
 
 using System;
+using System.Threading.Tasks;
 
 namespace OpenQA.Selenium.Appium.iOS.Interfaces
 {
@@ -26,21 +27,21 @@ namespace OpenQA.Selenium.Appium.iOS.Interfaces
         /// This method assumes that Appium server is running on localhost and
         /// is assigned to the default port (4723).
         /// </summary>
-        void StartSyslogBroadcast();
+        Task StartSyslogBroadcast();
 
         /// <summary>
         /// Start syslog messages broadcast via web socket.
         /// This method assumes that Appium server is assigned to the default port (4723).
         /// </summary>
         /// <param name="host">The name of the host where Appium server is running.</param>
-        void StartSyslogBroadcast(string host);
+        Task StartSyslogBroadcast(string host);
 
         /// <summary>
         /// Start syslog messages broadcast via web socket.
         /// </summary>
         /// <param name="host">The name of the host where Appium server is running.</param>
         /// <param name="port">The port of the host where Appium server is running.</param>
-        void StartSyslogBroadcast(string host, int port);
+        Task StartSyslogBroadcast(string host, int port);
 
         /// <summary>
         /// Adds a new log messages broadcasting handler.
@@ -86,6 +87,6 @@ namespace OpenQA.Selenium.Appium.iOS.Interfaces
         /// <summary>
         /// Stops syslog messages broadcast via web socket.
         /// </summary>
-        void StopSyslogBroadcast();
+        Task StopSyslogBroadcast();
     }
 }

--- a/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
+++ b/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
+using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.iOS;
 
@@ -64,14 +65,14 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
                 // Start syslog broadcast
                 await _driver.StartSyslogBroadcast();
                 // Wait for connection
-                Assert.That(connectionSemaphore.Wait(timeout), Is.True,
+                Assert.That(await connectionSemaphore.WaitAsync(timeout), Is.True,
                     "Failed to establish WebSocket connection within timeout");
                 Assert.That(connectionEstablished, Is.True,
                     "Connection listener was not invoked");
                 // Trigger some activity to generate log messages
                 _driver.BackgroundApp(TimeSpan.FromSeconds(1));
                 // Wait for at least one message
-                Assert.That(messageSemaphore.Wait(timeout), Is.True,
+                Assert.That(await messageSemaphore.WaitAsync(timeout), Is.True,
                     $"Didn't receive any log message after {timeout.TotalSeconds} seconds timeout");
                 Assert.That(messageReceived, Is.True,
                     "Message listener was not invoked");
@@ -127,7 +128,7 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
                 // Trigger activity to generate logs
                 _driver.BackgroundApp(TimeSpan.FromMilliseconds(500));
                 // Wait a bit for messages (both listeners should be called)
-                var received = messageSemaphore.Wait(TimeSpan.FromSeconds(5));
+                var received = await messageSemaphore.WaitAsync(TimeSpan.FromSeconds(5));
                 if (received)
                 {
                     // If we received messages, at least one listener should have been invoked
@@ -141,7 +142,7 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
                 // Trigger more activity
                 _driver.BackgroundApp(TimeSpan.FromMilliseconds(500));
                 // Wait a bit - no new messages should be counted after removing listeners
-                Thread.Sleep(2000);
+                await Task.Delay(2000);
                 Assert.That(messageCount, Is.EqualTo(0),
                     "No listeners should be invoked after removing all listeners");
             }
@@ -173,7 +174,7 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
                     await _driver.StartSyslogBroadcast();
 
                     // Give it time to connect
-                    Thread.Sleep(2000);
+                    await Task.Delay(2000);
                     // If we got here without errors during connection, that's good
                     if (!errorReceived)
                     {
@@ -188,9 +189,11 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
                             "Error should be captured by the error handler");
                     }
                 }
-                catch (AggregateException)
+                catch (WebDriverException)
                 {
-                    // Connection failure is expected in some environments
+                    // Connection failure is expected in some environments. Awaited calls surface
+                    // the underlying WebDriverException directly (not wrapped in AggregateException),
+                    // since StringWebSocketClient.ConnectAsync rethrows connection errors as such.
                     // Verify that error handler was invoked
                     Assert.That(errorReceived, Is.True,
                         "Error handler should be invoked when WebSocket connection fails");

--- a/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
+++ b/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
@@ -34,7 +34,9 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
         [Test]
         public async Task VerifySyslogListenerCanBeAssigned()
         {
-            using var messageSemaphore = new SemaphoreSlim(0, 1);
+            // Unbounded max so a burst of syslog messages (handler calls Release per message)
+            // can't overflow the semaphore and throw SemaphoreFullException.
+            using var messageSemaphore = new SemaphoreSlim(0, int.MaxValue);
             using var connectionSemaphore = new SemaphoreSlim(0, 1);
             var messageReceived = false;
             var connectionEstablished = false;
@@ -107,7 +109,8 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
         public async Task CanAddAndRemoveMultipleListeners()
         {
             var messageCount = 0;
-            using var messageSemaphore = new SemaphoreSlim(0, 10);
+            // Unbounded max so multiple listeners releasing per message can't overflow it.
+            using var messageSemaphore = new SemaphoreSlim(0, int.MaxValue);
             void listener1(string msg)
             {
                 Interlocked.Increment(ref messageCount);

--- a/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
+++ b/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Appium.Net.Integration.Tests.helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.iOS;
+
+namespace Appium.Net.Integration.Tests.IOS.Session.Logs
+{
+    [TestFixture]
+    [Category("iOS")]
+    internal class SyslogBroadcastTests
+    {
+        private IOSDriver _driver;
+        private AppiumOptions _iosOptions;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _iosOptions = Caps.GetIosCaps(Apps.Get("iosUICatalogApp"));
+            _driver = new IOSDriver(
+                Env.ServerIsLocal() ? AppiumServers.LocalServiceUri : AppiumServers.RemoteServerUri,
+                _iosOptions);
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            _driver?.Dispose();
+        }
+
+        [Test]
+        public async Task VerifySyslogListenerCanBeAssigned()
+        {
+            using var messageSemaphore = new SemaphoreSlim(0, 1);
+            using var connectionSemaphore = new SemaphoreSlim(0, 1);
+            var messageReceived = false;
+            var connectionEstablished = false;
+            var timeout = TimeSpan.FromSeconds(15);
+            // Add listeners
+            _driver.AddSyslogMessagesListener(msg =>
+            {
+                Console.WriteLine($"[SYSLOG] {msg}");
+                messageReceived = true;
+                messageSemaphore.Release();
+            });
+            _driver.AddSyslogConnectionListener(() =>
+            {
+                Console.WriteLine("Connected to the syslog web socket");
+                connectionEstablished = true;
+                connectionSemaphore.Release();
+            });
+            _driver.AddSyslogDisconnectionListener(() =>
+            {
+                Console.WriteLine("Disconnected from the syslog web socket");
+            });
+            _driver.AddSyslogErrorsListener(ex =>
+            {
+                Console.WriteLine($"Syslog error: {ex.Message}");
+            });
+            try
+            {
+                // Start syslog broadcast
+                await _driver.StartSyslogBroadcast();
+                // Wait for connection
+                Assert.That(connectionSemaphore.Wait(timeout), Is.True,
+                    "Failed to establish WebSocket connection within timeout");
+                Assert.That(connectionEstablished, Is.True,
+                    "Connection listener was not invoked");
+                // Trigger some activity to generate log messages
+                _driver.BackgroundApp(TimeSpan.FromSeconds(1));
+                // Wait for at least one message
+                Assert.That(messageSemaphore.Wait(timeout), Is.True,
+                    $"Didn't receive any log message after {timeout.TotalSeconds} seconds timeout");
+                Assert.That(messageReceived, Is.True,
+                    "Message listener was not invoked");
+            }
+            finally
+            {
+                // Clean up
+                await _driver.StopSyslogBroadcast();
+                _driver.RemoveAllSyslogListeners();
+            }
+        }
+
+        [Test]
+        public async Task CanStartAndStopSyslogBroadcast()
+        {
+            // Should not throw when starting and stopping
+            await _driver.StartSyslogBroadcast();
+            await _driver.StopSyslogBroadcast();
+        }
+
+        [Test]
+        public async Task CanStartSyslogBroadcastWithCustomHost()
+        {
+            var host = "127.0.0.1";
+            var port = 4723;
+
+            await _driver.StartSyslogBroadcast(host, port);
+            await _driver.StopSyslogBroadcast();
+        }
+
+        [Test]
+        public async Task CanAddAndRemoveMultipleListeners()
+        {
+            var messageCount = 0;
+            using var messageSemaphore = new SemaphoreSlim(0, 10);
+            void listener1(string msg)
+            {
+                Interlocked.Increment(ref messageCount);
+                messageSemaphore.Release();
+            }
+            void listener2(string msg)
+            {
+                Interlocked.Increment(ref messageCount);
+                messageSemaphore.Release();
+            }
+            try
+            {
+                await _driver.StartSyslogBroadcast();
+                // Add multiple listeners
+                _driver.AddSyslogMessagesListener(listener1);
+                _driver.AddSyslogMessagesListener(listener2);
+
+                // Trigger activity to generate logs
+                _driver.BackgroundApp(TimeSpan.FromMilliseconds(500));
+                // Wait a bit for messages (both listeners should be called)
+                var received = messageSemaphore.Wait(TimeSpan.FromSeconds(5));
+                if (received)
+                {
+                    // If we received messages, at least one listener should have been invoked
+                    Assert.That(messageCount, Is.GreaterThanOrEqualTo(1),
+                        "At least one listener should have been invoked");
+                }
+                // Remove all listeners
+                _driver.RemoveAllSyslogListeners();
+                // Reset counter
+                messageCount = 0;
+                // Trigger more activity
+                _driver.BackgroundApp(TimeSpan.FromMilliseconds(500));
+                // Wait a bit - no new messages should be counted after removing listeners
+                Thread.Sleep(2000);
+                Assert.That(messageCount, Is.EqualTo(0),
+                    "No listeners should be invoked after removing all listeners");
+            }
+            finally
+            {
+                await _driver.StopSyslogBroadcast();
+                _driver.RemoveAllSyslogListeners();
+            }
+        }
+
+        [Test]
+        public async Task CanHandleErrorsGracefully()
+        {
+            var errorReceived = false;
+            using var errorSemaphore = new SemaphoreSlim(0, 1);
+            Exception capturedError = null;
+            _driver.AddSyslogErrorsListener(ex =>
+            {
+                Console.WriteLine($"Error handler invoked: {ex.Message}");
+                capturedError = ex;
+                errorReceived = true;
+                errorSemaphore.Release();
+            });
+            try
+            {
+                // Start broadcast - may fail if endpoint is not available
+                try
+                {
+                    await _driver.StartSyslogBroadcast();
+
+                    // Give it time to connect
+                    Thread.Sleep(2000);
+                    // If we got here without errors during connection, that's good
+                    if (!errorReceived)
+                    {
+                        Assert.Pass("Syslog broadcast started successfully without errors");
+                    }
+                    else
+                    {
+                        // If error occurred during startup, verify error handler was invoked
+                        Assert.That(errorReceived, Is.True,
+                            "Error handler should be invoked when connection fails");
+                        Assert.That(capturedError, Is.Not.Null,
+                            "Error should be captured by the error handler");
+                    }
+                }
+                catch (AggregateException)
+                {
+                    // Connection failure is expected in some environments
+                    // Verify that error handler was invoked
+                    Assert.That(errorReceived, Is.True,
+                        "Error handler should be invoked when WebSocket connection fails");
+                    Assert.That(capturedError, Is.Not.Null,
+                        "Error should be captured by the error handler");
+                }
+            }
+            finally
+            {
+                try
+                {
+                    await _driver.StopSyslogBroadcast();
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Exception during StopSyslogBroadcast: {ex}");
+                }
+                _driver.RemoveAllSyslogListeners();
+            }
+        }
+    }
+}

--- a/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
+++ b/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
@@ -142,6 +142,11 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
                 }
                 // Remove all listeners
                 _driver.RemoveAllSyslogListeners();
+                // Drain any in-flight dispatch: a message already read from the socket before
+                // removal can still invoke the previously captured delegate. Wait for those to
+                // settle before resetting the counter so the post-removal assertion only reflects
+                // callbacks triggered after removal.
+                await Task.Delay(1000);
                 // Reset counter
                 messageCount = 0;
                 // Trigger more activity

--- a/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
+++ b/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
@@ -130,7 +130,9 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
 
                 // Trigger activity to generate logs
                 _driver.BackgroundApp(TimeSpan.FromMilliseconds(500));
-                // Wait a bit for messages (both listeners should be called)
+                // Wait until at least one listener invocation is signalled. The semaphore wakes
+                // on the first listener to fire, so we only assert that a listener was invoked
+                // (not that both have run by this point) to keep the test deterministic.
                 var received = await messageSemaphore.WaitAsync(TimeSpan.FromSeconds(5));
                 if (received)
                 {

--- a/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
+++ b/test/integration/IOS/Session/Logs/SyslogBroadcastTests.cs
@@ -157,14 +157,12 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
         public async Task CanHandleErrorsGracefully()
         {
             var errorReceived = false;
-            using var errorSemaphore = new SemaphoreSlim(0, 1);
             Exception capturedError = null;
             _driver.AddSyslogErrorsListener(ex =>
             {
                 Console.WriteLine($"Error handler invoked: {ex.Message}");
                 capturedError = ex;
                 errorReceived = true;
-                errorSemaphore.Release();
             });
             try
             {


### PR DESCRIPTION
Wire the existing IListensToSyslogMessages interface into IOSDriver,
mirroring the Android logcat broadcast implementation. Adds WebSocket-based
real-time iOS syslog streaming via the Appium
ws://<host>:<port>/ws/session/<id>/appium/device/syslog endpoint.

- IOSDriver now implements IListensToSyslogMessages using a
  StringWebSocketClient, with Start/StopSyslogBroadcast, listener
  registration (messages, errors, connect, disconnect) and
  RemoveAllSyslogListeners.
- Change IListensToSyslogMessages Start/StopSyslogBroadcast return types
  from void to Task to match the async implementation and the Android
  IListensToLogcatMessages contract.
- Add SyslogBroadcastTests integration tests paralleling the Android
  LogcatBroadcastTests suite.

Completes the iOS half of the log broadcast feature (Android was merged
in appium/dotnet-client#969).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lqd5nmE69tYMpCVYZ8ySrT